### PR TITLE
Add functionality to handle array of options as found in .babelrcArray

### DIFF
--- a/.babelrcArray
+++ b/.babelrcArray
@@ -1,0 +1,17 @@
+{
+  "plugins": [
+    [
+      "babel-root-import",
+      [
+        {
+          "rootPathSuffix": "test/somepath",
+          "rootPathPrefix": "@"
+        },
+        {
+          "rootPathSuffix": "test/anotherpath",
+          "rootPathPrefix": "_"
+        }
+      ]
+    ],
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-import-resolver-babel-root-import",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "main": "src/index.js",
   "description": "babel-plugin-root-import resolver for eslint-plugin-import",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,12 @@
     "email": "olalonde@gmail.com",
     "url": "http://syskall.com"
   },
+  "contributors": [
+    {
+      "name": "Christian Le",
+      "url": "http://christianle.com"
+    }
+  ],
   "license": "MIT",
   "keywords": [
     "eslint",
@@ -59,3 +65,4 @@
     ]
   }
 }
+

--- a/src/index.js
+++ b/src/index.js
@@ -28,13 +28,13 @@ if (babelRootImport.default) {
 function getConfigFromBabel(start, babelrc = '.babelrc') {
     if (start === '/') return [];
 
-    const packageJSONPath = path.join(start, babelrc);
+    const packageJSONPath = path.join(start, 'package.json');
     const packageJSON = require(packageJSONPath);
     const babelConfig = packageJSON.babel;
     if (babelConfig) {
-        const pluginConfig = babelConfig.plugins.find(p => {
+        const pluginConfig = babelConfig.plugins.find(p => (
             p[0] === 'babel-root-import'
-        });
+        ));
         process.chdir(path.dirname(packageJSONPath));
         return pluginConfig[1];
     }

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,17 @@ if (babelRootImport.default) {
 function getConfigFromBabel(start, babelrc = '.babelrc') {
     if (start === '/') return [];
 
+    const packageJSONPath = path.join(start, babelrc);
+    const packageJSON = require(packageJSONPath);
+    const babelConfig = packageJSON.babel;
+    if (babelConfig) {
+        const pluginConfig = babelConfig.plugins.find(p => {
+            p[0] === 'babel-root-import'
+        });
+        process.chdir(path.dirname(packageJSONPath));
+        return pluginConfig[1];
+    }
+
     const babelrcPath = path.join(start, babelrc);
     if (fs.existsSync(babelrcPath)) {
         const babelrcJson = JSON5.parse(fs.readFileSync(babelrcPath, 'utf8'));

--- a/src/index.js
+++ b/src/index.js
@@ -25,12 +25,12 @@ if (babelRootImport.default) {
 }
 
 // returns the root import config as an object
-function getConfigFromBabel(start) {
+function getConfigFromBabel(start, babelrc = '.babelrc') {
     if (start === '/') return [];
 
-    const babelrc = path.join(start, '.babelrc');
-    if (fs.existsSync(babelrc)) {
-        const babelrcJson = JSON5.parse(fs.readFileSync(babelrc, 'utf8'));
+    const babelrcPath = path.join(start, babelrc);
+    if (fs.existsSync(babelrcPath)) {
+        const babelrcJson = JSON5.parse(fs.readFileSync(babelrcPath, 'utf8'));
         if (babelrcJson && Array.isArray(babelrcJson.plugins)) {
             const pluginConfig = babelrcJson.plugins.find(p => (
                 p[0] === 'babel-root-import'
@@ -38,7 +38,7 @@ function getConfigFromBabel(start) {
             // The src path inside babelrc are from the root so we have
             // to change the working directory for the same directory
             // to make the mapping to work properly
-            process.chdir(path.dirname(babelrc));
+            process.chdir(path.dirname(babelrcPath));
             return pluginConfig[1];
         }
     }
@@ -54,28 +54,60 @@ exports.interfaceVersion = 2;
  * @param  {string} source - the module to resolve; i.e './some-module'
  * @param  {string} file - the importing file's full path; i.e. '/usr/local/bin/file.js'
  * @param  {object} config - the resolver options
+ * @param  {string} babelrc - the name of the babelrc file
  * @return {object}
  */
-exports.resolve = (source, file, config) => {
-    const opts = getConfigFromBabel(process.cwd());
+exports.resolve = (source, file, config, babelrc) => {
+    const opts = getConfigFromBabel(process.cwd(), babelrc);
 
-    let rootPathSuffix = '';
-    let rootPathPrefix = '';
+    // [{rootPathPrefix: rootPathSuffix}]
+    const rootPathConfig = [];
 
-    if (opts.rootPathSuffix && typeof opts.rootPathSuffix === 'string') {
-        rootPathSuffix = `/${opts.rootPathSuffix.replace(/^(\/)|(\/)$/g, '')}`;
-    }
+    if (Array.isArray(opts)) {
+        opts.forEach((option) => {
+            let prefix = '';
+            if (option.rootPathPrefix && typeof option.rootPathPrefix === 'string') {
+                prefix = option.rootPathPrefix;
+            }
 
-    if (opts.rootPathPrefix && typeof opts.rootPathPrefix === 'string') {
-        rootPathPrefix = opts.rootPathPrefix;
+            let suffix = '';
+            if (option.rootPathSuffix && typeof option.rootPathSuffix === 'string') {
+                suffix = `/${option.rootPathSuffix.replace(/^(\/)|(\/)$/g, '')}`;
+            }
+
+            rootPathConfig.push({
+                rootPathPrefix: prefix,
+                rootPathSuffix: suffix
+            });
+        });
     } else {
-        rootPathPrefix = '~';
+        let rootPathPrefix = '~';
+        if (opts.rootPathPrefix && typeof opts.rootPathPrefix === 'string') {
+            rootPathPrefix = opts.rootPathPrefix;
+        }
+
+        let rootPathSuffix = '';
+        if (opts.rootPathSuffix && typeof opts.rootPathSuffix === 'string') {
+            rootPathSuffix = `/${opts.rootPathSuffix.replace(/^(\/)|(\/)$/g, '')}`;
+        }
+
+        rootPathConfig.push({
+            rootPathPrefix,
+            rootPathSuffix
+        });
     }
 
     let transformedSource = source;
-    if (hasRootPathPrefixInString(source, rootPathPrefix)) {
-        transformedSource = transformRelativeToRootPath(source, rootPathSuffix, rootPathPrefix);
+    for (let i = 0; i < rootPathConfig.length; i += 1) {
+        const option = rootPathConfig[i];
+        const prefix = option.rootPathPrefix;
+        const suffix = option.rootPathSuffix;
+        if (hasRootPathPrefixInString(source, option.rootPathPrefix)) {
+            transformedSource = transformRelativeToRootPath(source, suffix, prefix);
+            break;
+        }
     }
 
     return nodeResolve(transformedSource, file, config);
 };
+

--- a/test/anotherpath/file.js
+++ b/test/anotherpath/file.js
@@ -1,0 +1,1 @@
+module.exports = 'some value';

--- a/test/index.js
+++ b/test/index.js
@@ -8,5 +8,19 @@ test((t) => {
         found: true,
         path: path.resolve(__dirname, 'somepath/file.js'),
     });
+
+    const result2 = resolve('@/file', __filename, {}, '.babelrcArray');
+    t.deepEqual(result2, {
+        found: true,
+        path: path.resolve(__dirname, 'somepath/file.js'),
+    });
+
+    const result3 = resolve('_/file', __filename, {}, '.babelrcArray');
+    t.deepEqual(result3, {
+        found: true,
+        path: path.resolve(__dirname, 'anotherpath/file.js'),
+    });
+
     t.end();
 });
+


### PR DESCRIPTION
`babel-root-import` allows you to pass an array of objects with key `rootPathPrefix` and value `rootPathSuffix`.

You can see that it looks through all of the `options` in `replacePrefix` https://github.com/michaelzoidl/babel-root-import/blob/master/plugin/index.js

This adds the functionality to use arrays in `.babelrc` like in the `.babelrcArray` file.
