### PR TITLE
Support passing options via lint settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,13 @@ your prefix/suffix.
   "rules": {},
   "settings": {
     "import/resolver": {
-      "babel-plugin-root-import": {}
+      "babel-plugin-root-import": {
+        "babelrc": ".customBabelrc",
+        "options": [{
+          "rootPathPrefix": "~",
+          "rootPathSuffix": "src/"
+        }]
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-import-resolver-babel-root-import",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "src/index.js",
   "description": "babel-plugin-root-import resolver for eslint-plugin-import",
   "repository": {
@@ -16,6 +16,10 @@
     {
       "name": "Christian Le",
       "url": "http://christianle.com"
+    },
+    {
+      "name": "Yuseong Cho",
+      "email": "gg6123@naver.com"
     }
   ],
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,7 @@ exports.interfaceVersion = 2;
  * @param  {string} file - the importing file's full path; i.e. '/usr/local/bin/file.js'
  * @param  {object} config - the resolver options
  * @param  {string} [config.babelrc] - the path of the babelrc file
- * @param  {string} [config.options] - the options passed to the plugin
+ * @param  {(object|array)} [config.options] - the options passed to the plugin
  * @return {object}
  */
 exports.resolve = (source, file, config) => {

--- a/src/options.js
+++ b/src/options.js
@@ -1,0 +1,94 @@
+const path = require('path');
+const fs = require('fs');
+const JSON5 = require('json5');
+
+const ROOT_PATH = path.resolve('/');
+
+const PLUGIN_NAMES = [
+    'babel-plugin-root-import',
+    'babel-root-import',
+    'root-import',
+];
+
+const existsBabelrc = (filepath) => (
+    fs.existsSync(filepath)
+);
+
+const parseBabelrc = (filepath) => (
+    JSON5.parse(fs.readFileSync(filepath, 'utf-8'))
+);
+
+const existsPackage = (filepath) => (
+    // eslint-disable-next-line global-require
+    fs.existsSync(filepath) && !!(require(filepath).babel)
+);
+
+const parsePackage = (filepath) => (
+    // eslint-disable-next-line global-require
+    require(filepath).babel
+);
+
+const extractOptions = babelConfig => {
+    let plugin;
+
+    if (babelConfig && babelConfig.plugins) {
+        plugin = babelConfig.plugins.find(([pluginName]) => (
+            PLUGIN_NAMES.includes(pluginName)
+        ));
+    }
+
+    return (plugin ? plugin[1] : []);
+};
+
+const mergeOptions = (...options) => (
+    options.reduce((result, item) => {
+        if (Array.isArray(item)) {
+            result.push(...item);
+        } else {
+            result.push(item);
+        }
+
+        return result;
+    }, [])
+);
+
+const getOptions = (lintConfig, cwd) => {
+    // If all trials fail until reaching the root, stop finding
+    if (cwd === ROOT_PATH) {
+        return null;
+    }
+
+    // If the lint config exists, just use it
+    if (lintConfig) {
+        const babelrcOptions = lintConfig.babelrc && (
+            extractOptions(parseBabelrc(path.resolve(cwd, lintConfig.babelrc)))
+        );
+
+        if (babelrcOptions && lintConfig.options) {
+            return mergeOptions(babelrcOptions, lintConfig.options);
+        } else if (babelrcOptions) {
+            return babelrcOptions;
+        } else if (lintConfig.options) {
+            return lintConfig.options;
+        }
+    }
+
+    // Otherwise, find .babelrc file from the cwd
+    const babelrcPath = path.join(cwd, '.babelrc');
+
+    if (existsBabelrc(babelrcPath)) {
+        return extractOptions(parseBabelrc(babelrcPath));
+    }
+
+    // Otherwise, check if package.json has babel section
+    const packagePath = path.join(cwd, 'package.json');
+
+    if (existsPackage(packagePath)) {
+        return extractOptions(parsePackage(packagePath));
+    }
+
+    // If all trials fail, retry from the parent directory
+    return getOptions(lintConfig, path.resolve(cwd, '..'));
+};
+
+exports.getOptions = getOptions;

--- a/test/index.js
+++ b/test/index.js
@@ -9,14 +9,20 @@ test((t) => {
         path: path.resolve(__dirname, 'somepath/file.js'),
     });
 
-    const result2 = resolve('@/file', __filename, {}, '.babelrcArray');
+    const result2 = resolve('@/file', __filename, { options: { rootPathSuffix: 'test/somepath', rootPathPrefix: '@' } });
     t.deepEqual(result2, {
         found: true,
         path: path.resolve(__dirname, 'somepath/file.js'),
     });
 
-    const result3 = resolve('_/file', __filename, {}, '.babelrcArray');
+    const result3 = resolve('@/file', __filename, { babelrc: '.babelrcArray' });
     t.deepEqual(result3, {
+        found: true,
+        path: path.resolve(__dirname, 'somepath/file.js'),
+    });
+
+    const result4 = resolve('_/file', __filename, { babelrc: '.babelrcArray' });
+    t.deepEqual(result4, {
         found: true,
         path: path.resolve(__dirname, 'anotherpath/file.js'),
     });


### PR DESCRIPTION
This PR supports passing options via lint settings.

You can set custom `.babelrc` file path, or set `rootPathPrefix` and `rootPathSuffix` options as the same way babel plugin handles. If both are given, all options will be merged.